### PR TITLE
Data types conversion fixes, CKAN resource naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 |Parameter                                       |Description                                                              |
 |------------------------------------------------|-------------------------------------------------------------------------|
+|**CKAN resource name**                          |Name of CKAN resource to be created                                      |
 |                                                |                                                                         |
 
 ***
@@ -43,6 +44,7 @@ In order to work properly, this DPU needs configuration parameters properly set 
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
+|1.1.0            | Resource name in CKAN is now configured by user; Only one table can be processed by DPU |
 |1.0.1            | bug fixes and update in build dependencies |
 |1.0.0            | First version              |
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.opendatanode.plugins</groupId>
 	<artifactId>uv-l-relationaldiffToCkan</artifactId>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<packaging>bundle</packaging>
 	<name>L-RelationalDiffToCkan</name>
 	<description>Performs update of input relational data into CKAN datastore using CKAN API and thin proxy</description>

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkan.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkan.java
@@ -9,9 +9,9 @@ import java.sql.Statement;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -139,47 +139,51 @@ public class RelationalDiffToCkan extends AbstractDpu<RelationalDiffToCkanConfig
 
         CatalogApiConfig apiConfig = new CatalogApiConfig(catalogApiLocation, pipelineId, userId, token);
 
-        Iterator<RelationalDataUnit.Entry> tablesIteration;
+        Set<RelationalDataUnit.Entry> internalTables;
         try {
-            tablesIteration = RelationalHelper.getTables(this.tablesInput).iterator();
+            internalTables = RelationalHelper.getTables(this.tablesInput);
         } catch (DataUnitException ex) {
             ContextUtils.sendError(this.ctx, "errors.dpu.failed", ex, "errors.tables.iterator");
             return;
         }
 
+        if (internalTables.size() != 1) {
+            LOG.error("DPU can process only one input database table; Actual count of tables: {}", internalTables.size());
+            throw ContextUtils.dpuException(this.ctx, "errors.input.tables");
+        }
+
         Map<String, String> existingResources = getExistingResources(apiConfig);
 
         try {
-            while (!this.context.canceled() && tablesIteration.hasNext()) {
-                final RelationalDataUnit.Entry entry = tablesIteration.next();
-                final String sourceTableName = entry.getTableName();
-                LOG.debug("Going to load table {} to CKAN dataset as resource", sourceTableName);
-                try {
-                    if (existingResources.containsKey(sourceTableName)) {
-                        LOG.info("Resource already exists, overwrite mode is enabled -> resource will be updated");
-                        String resourceId = existingResources.get(sourceTableName);
-                        updateCkanResource(entry, resourceId, apiConfig);
-                        updateAuditedDatastoreFromTable(entry, resourceId, apiConfig);
-                        LOG.info("Resource and datastore for table {} successfully updated", sourceTableName);
-                        ContextUtils.sendShortInfo(this.ctx, "dpu.resource.updated", sourceTableName);
+            final RelationalDataUnit.Entry entry = internalTables.iterator().next();
+            final String sourceTableName = entry.getTableName();
+            final String resourceName = config.getResourceName();
+            LOG.debug("Going to load table {} to CKAN dataset as resource {}", sourceTableName, resourceName);
+            try {
+                if (existingResources.containsKey(resourceName)) {
+                    LOG.info("Resource already exists, overwrite mode is enabled -> resource will be updated");
+                    String resourceId = existingResources.get(resourceName);
+                    updateCkanResource(entry, resourceId, apiConfig);
+                    updateAuditedDatastoreFromTable(entry, resourceId, apiConfig);
+                    LOG.info("Resource and datastore {} for table {} successfully updated", resourceName, sourceTableName);
+                    ContextUtils.sendShortInfo(this.ctx, "dpu.resource.updated", resourceName);
 
-                    } else {
-                        LOG.info("Resource does not exist yet, it will be created");
-                        String resourceId = createCkanResource(entry, apiConfig);
-                        try {
-                            createAuditedDatastoreFromTable(entry, resourceId, apiConfig);
-                            LOG.info("Resource and datastore for table {} successfully created", sourceTableName);
-                        } catch (Exception e) {
-                            LOG.debug("Failed to create datastore for resource {}, going to delete resource", resourceId);
-                            deleteCkanResource(resourceId, apiConfig);
-                        }
-                        ContextUtils.sendShortInfo(this.ctx, "dpu.resource.created", sourceTableName);
+                } else {
+                    LOG.info("Resource does not exist yet, it will be created");
+                    String resourceId = createCkanResource(entry, apiConfig);
+                    try {
+                        createAuditedDatastoreFromTable(entry, resourceId, apiConfig);
+                        LOG.info("Resource and datastore {} for table {} successfully created", resourceName, sourceTableName);
+                    } catch (Exception e) {
+                        LOG.debug("Failed to create datastore for resource {}, going to delete resource", resourceId);
+                        deleteCkanResource(resourceId, apiConfig);
                     }
-                } catch (Exception e) {
-                    LOG.error("Failed to create resource / datastore for table {}", sourceTableName, e);
-                    this.context.sendMessage(DPUContext.MessageType.ERROR,
-                            this.ctx.tr("dpu.resource.upload", sourceTableName));
+                    ContextUtils.sendShortInfo(this.ctx, "dpu.resource.created", resourceName);
                 }
+            } catch (Exception e) {
+                LOG.error("Failed to create resource / datastore {} for table {}", resourceName, sourceTableName, e);
+                this.context.sendMessage(DPUContext.MessageType.ERROR,
+                        this.ctx.tr("dpu.resource.upload", resourceName, sourceTableName));
             }
         } catch (DataUnitException e) {
             ContextUtils.dpuException(this.ctx, e, "errors.dpu.upload");
@@ -256,9 +260,9 @@ public class RelationalDiffToCkan extends AbstractDpu<RelationalDiffToCkanConfig
         CloseableHttpClient client = HttpClients.createDefault();
         CloseableHttpResponse response = null;
         try {
-            String storageId = table.getTableName();
+            String resourceName = this.config.getResourceName();
             Resource resource = ResourceHelpers.getResource(this.tablesInput, table.getSymbolicName());
-            resource.setName(storageId);
+            resource.setName(resourceName);
             JsonObjectBuilder resourceBuilder = buildResource(factory, resource);
 
             URIBuilder uriBuilder = new URIBuilder(apiConfig.getCatalogApiLocation());
@@ -353,10 +357,10 @@ public class RelationalDiffToCkan extends AbstractDpu<RelationalDiffToCkanConfig
         CloseableHttpClient client = HttpClients.createDefault();
         CloseableHttpResponse response = null;
         try {
-            String storageId = table.getTableName();
+            String resourceName = this.config.getResourceName();
             Resource resource = ResourceHelpers.getResource(this.tablesInput, table.getSymbolicName());
             resource.setCreated(null);
-            resource.setName(storageId);
+            resource.setName(resourceName);
             JsonObjectBuilder resourceBuilder = buildResource(factory, resource);
             resourceBuilder.add(CKAN_API_RESOURCE_ID, resourceId);
 

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkanConfig_V1.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkanConfig_V1.java
@@ -1,5 +1,15 @@
 package eu.unifiedviews.plugins.loader.relationaldifftockan;
 
 public class RelationalDiffToCkanConfig_V1 {
+    
+    private String resourceName;
+
+    public String getResourceName() {
+        return this.resourceName;
+    }
+
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
 
 }

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkanHelper.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkanHelper.java
@@ -191,9 +191,10 @@ public class RelationalDiffToCkanHelper {
         JsonArrayBuilder fieldsBuilder = factory.createArrayBuilder();
 
         for (ColumnDefinition column : columns) {
+            String dataTypeName = convertDataTypeForCkanIfNeeded(column.getColumnTypeName());
             fieldsBuilder.add(factory.createObjectBuilder()
                     .add("id", column.getColumnName())
-                    .add("type", column.getColumnTypeName()));
+                    .add("type", dataTypeName));
         }
 
         return fieldsBuilder.build();
@@ -236,6 +237,7 @@ public class RelationalDiffToCkanHelper {
                     case Types.VARCHAR:
                     case Types.LONGNVARCHAR:
                     case Types.LONGVARCHAR:
+                    case Types.CLOB:
                         entryBuilder.add(column.getColumnName(), rs.getString(column.getColumnName()));
                         break;
 
@@ -262,8 +264,7 @@ public class RelationalDiffToCkanHelper {
                         break;
 
                     case Types.BLOB:
-                    case Types.CLOB:
-                        // TODO: implement BLOB/CLOB conversion
+                        // TODO: implement BLOB conversion
                         entryBuilder.addNull(column.getColumnName());
                         break;
 
@@ -288,6 +289,45 @@ public class RelationalDiffToCkanHelper {
         }
 
         return recordsBuilder.build();
+    }
+    
+    /**
+     * Mapping from H2 (used as internal dataunit database) types to PostgreSQL types (used in CKAN datastore)
+     * @param dataTypeName SQL type
+     * @return Converted SQL type if needed
+     */
+     private static String convertDataTypeForCkanIfNeeded(String dataTypeName) {
+        String convertedDataTypeName = dataTypeName;
+        switch (dataTypeName.toUpperCase()) {
+            case "CLOB":
+                convertedDataTypeName = "TEXT";
+                break;
+            case "TINYINT":
+                convertedDataTypeName = "SMALLINT";
+                break;
+            case "INT":
+                convertedDataTypeName = "INTEGER";
+                break;
+            case "DOUBLE":
+                convertedDataTypeName = "DOUBLE PRECISION";
+                break;
+            case "IDENTITY":
+                convertedDataTypeName = "BIGINT";
+                break;
+            case "BINARY":
+            case "BLOB":
+                convertedDataTypeName = "BYTEA";
+                break;
+            case "GEOMETRY":
+            case "VARCHAR_IGNORECASE":
+                convertedDataTypeName = "VARCHAR";
+                break;
+            case "ARRAY":
+                convertedDataTypeName = "VARCHAR ARRAY";
+                break;
+        }
+        
+        return convertedDataTypeName;
     }
 
     private static JsonArrayBuilder getSqlArrayAsJsonArray(JsonBuilderFactory factory, Array array) throws SQLException {

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkanVaadinDialog.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaldifftockan/RelationalDiffToCkanVaadinDialog.java
@@ -1,5 +1,9 @@
 package eu.unifiedviews.plugins.loader.relationaldifftockan;
 
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.VerticalLayout;
+
 import eu.unifiedviews.dpu.config.DPUConfigException;
 import eu.unifiedviews.helpers.dpu.vaadin.dialog.AbstractDialog;
 
@@ -7,23 +11,53 @@ public class RelationalDiffToCkanVaadinDialog extends AbstractDialog<RelationalD
 
     private static final long serialVersionUID = 3627915032084995009L;
 
+    private VerticalLayout mainLayout;
+
+    private TextField txtResourceName;
+
     public RelationalDiffToCkanVaadinDialog() {
         super(RelationalDiffToCkan.class);
     }
 
     @Override
     protected void buildDialogLayout() {
-        // DPU has no dialog
+        setWidth("100%");
+        setHeight("100%");
+
+        this.mainLayout = new VerticalLayout();
+        this.mainLayout.setWidth("100%");
+        this.mainLayout.setHeight("-1px");
+        this.mainLayout.setSpacing(true);
+        this.mainLayout.setMargin(true);
+
+        this.txtResourceName = new TextField();
+        this.txtResourceName.setNullRepresentation("");
+        this.txtResourceName.setRequired(true);
+        this.txtResourceName.setCaption(this.ctx.tr("dialog.ckan.resource.name"));
+        this.txtResourceName.setWidth("100%");
+        this.txtResourceName.setDescription(this.ctx.tr("dialog.resource.name.help"));
+        this.mainLayout.addComponent(this.txtResourceName);
+
+        Panel panel = new Panel();
+        panel.setSizeFull();
+        panel.setContent(this.mainLayout);
+        setCompositionRoot(panel);
     }
 
     @Override
-    protected void setConfiguration(RelationalDiffToCkanConfig_V1 conf) throws DPUConfigException {
-        // DPU has no configuration
+    protected void setConfiguration(RelationalDiffToCkanConfig_V1 config) throws DPUConfigException {
+        this.txtResourceName.setValue(config.getResourceName());
     }
 
     @Override
     protected RelationalDiffToCkanConfig_V1 getConfiguration() throws DPUConfigException {
+        boolean isValid = this.txtResourceName.isValid();
+        if (!isValid) {
+            throw new DPUConfigException(ctx.tr("dialog.errors.params"));
+        }
+
         RelationalDiffToCkanConfig_V1 config = new RelationalDiffToCkanConfig_V1();
+        config.setResourceName(this.txtResourceName.getValue());
         return config;
     }
 

--- a/src/main/resources/about.html
+++ b/src/main/resources/about.html
@@ -12,3 +12,11 @@ In order to work properly, these two parameters must be set in backend config.pr
 </ul>
 <br/>
 Also, prior to running this DPU, an association between pipeline and CKAN dataset must exist, otherwise DPU fails 
+
+<p/>
+List of options:
+<ul>
+	<li><b>CKAN resource name</b> - (required) Name of resource to be created in CKAN. It should not change between pipeline runs as this name
+	is used as key to CKAN.
+</ul>
+<br/>

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -1,15 +1,13 @@
 # Messages
 dpu.ckan.starting = {0} is starting.
-dpu.resource.created = Resource and datastore for table {0} were created
-dpu.resource.updated = Resource and datastore for table {0} were updated 
+dpu.resource.created = Resource and datastore {0} were created
+dpu.resource.updated = Resource and datastore {0} were updated 
 
 # Errors
 errors.dpu.failed = Execution of DPU failed
 errors.tables.iterator = Failed to obtain input database tables
-dpu.resource.skipped.short = Creating resource for table {0} skipped
-dpu.resource.skipped.long = Resource was skipped because it already exists in the catalog and overwrite mode is not enabled
-dpu.resource.upload = Failed to create resource and datastore for database table {0}
-errors.dpu.upload = Internal error occurred during creating catalog resources from internal database tables 
+dpu.resource.upload = Failed to create resource and datastore {0} for database table {1}
+errors.dpu.upload = Internal error occurred during creating catalog resource from internal database table 
 errors.dpu.dataset = Failed to obtain list of existing resources for the pipeline
 dpu.resource.dataseterror = Could not obtain Dataset entity from CKAN. Response: {0}
 errors.token.missing = Missing authentication token for catalog API
@@ -18,3 +16,8 @@ errors.primarykeys = Primary keys definition in source table required when creat
 errors.resource.delete = Failed to delete CKAN resource
 errors.resource.delete.long = CKAN resource has to be manually deleted in CKAN before rerunning this pipeline
 dpu.resource.responseerror = CKAN responded that operation was not successful. See logs for error details
+
+#Dialog
+dialog.ckan.resource.name = CKAN resource name
+dialog.errors.params = Required configuration parameters missing
+dialog.resource.name.help = This name should not change between pipeline runs as it is used as key to CKAN. If name changes, existing resource in CKAN will not be updated and new resource will be created

--- a/src/main/resources/resources_sk.properties
+++ b/src/main/resources/resources_sk.properties
@@ -1,15 +1,13 @@
 
 # Messages
 dpu.ckan.starting = {0} \u0161tartuje.
-dpu.resource.created = Zdroj a datastore pre tabu\u013Eku {0} boli vytvorené
-dpu.resource.updated = Zdroj a datastore pre tabu\u013Eku {0} boli aktualizované 
+dpu.resource.created = Zdroj a datastore {0} boli vytvorené
+dpu.resource.updated = Zdroj a datastore {0} boli aktualizované 
 
 # Errors
 errors.dpu.failed = Vykonávanie kroku zlyhalo
 errors.tables.iterator = Nepodarilo sa na\u010Díta\u0165 vstupné databázové tabu\u013Eky
-dpu.resource.skipped.short = Vytváranie zdroja pre tabu\u013Eku {0} vynechané
-dpu.resource.skipped.long = Zdroj bol vynechaný, preto\u017Ee u\u017E existuje v katalógu a prepisovací mód nie je zapnutý
-dpu.resource.upload = Nepodarilo sa vytvori\u0165 zdroj a datastore pre databázovú tabu\u013Eku {0}
+dpu.resource.upload = Nepodarilo sa vytvori\u0165 zdroj a datastore {0} pre databázovú tabu\u013Eku {1}
 errors.dpu.upload = Nastala interná chyba pri vytváraní katalógových zdrojov zo vstupných tabuliek   
 errors.dpu.dataset = Nepodarilo sa získa\u0165 zoznam existujúcich zdrojov pre tento proces
 dpu.resource.dataseterror = Nepodarilo sa získa\u0165 Dataset z CKAN. Odpove\u010F: {0}
@@ -19,3 +17,8 @@ errors.primarykeys = Primárne k\u013Eú\u010De pre zdrojovú tabu\u013Eku nie sú d
 errors.resource.delete = Nepodarilo sa vymaza\u0165 CKAN zdroj
 errors.resource.delete.long = CKAN zdroj musí by\u0165 manuálne vymazaný pred opätovným spustením procesu
 dpu.resource.responseerror = CKAN odpovedal, \u017Ee operácia bola neúspe\u0161ná. Pre podrobnosti prezrite logy
+
+# Dialog
+dialog.ckan.resource.name = Názov zdroja v CKANe
+dialog.errors.params = Chýbajú povinné konfigura\u010Dné parametre
+dialog.resource.name.help = Tento názov by sa nemal meni\u0165 medzi jednotlivými behmi procesu. Názov zdroja je pou\u017Eitý ako k\u013Eú\u010D do CKANu. Ak sa názov zmení, zdroj v CKANe nebude aktualizovaný a bude vytvorený v\u017Edy nový


### PR DESCRIPTION
Fixed conversion of data types from internal UV database (H2) to CKAN (PostgreSQL).
Added new mandatory parameter for CKAN resource name; Now user must provide name for CKAN resource and DPU can process only one input databse table (fails if user attempts to process multiple tables)
